### PR TITLE
Fix new feature test: regular hour not change even if on SOLID Wednesday

### DIFF
--- a/java/src/test/java/community/dddtw/refactor/initial/EmployeeTest.java
+++ b/java/src/test/java/community/dddtw/refactor/initial/EmployeeTest.java
@@ -44,7 +44,7 @@ class EmployeeTest {
 //     TODO: Fix it to meet the new requirement
 //    @Test
 //    void test_report_on_solid_wednesday() {
-//        assertEquals(this.employee.reportHours(), "Regular Hours: 40");
+//        assertEquals(this.employee.reportHours(), "Regular Hours: 37");
 //    }
 
 


### PR DESCRIPTION
The `regularHour` should stay the same even on SOLID Wednesday.